### PR TITLE
学年検索と名前検索を/membersで処理できるよう変更

### DIFF
--- a/src/main/java/com/raisetech/membershipmanagement/controller/MemberController.java
+++ b/src/main/java/com/raisetech/membershipmanagement/controller/MemberController.java
@@ -26,14 +26,14 @@ public class MemberController {
     その他の場合はBadRequestを返す処理
     */
     @GetMapping("/members")
-    public List<Member> getMembers(@RequestParam String name, String type, Integer number) {
+    public List<Member> getMembers(@RequestParam(required = false) String name, String type, Integer number) {
         if (name == null) {
             if ((type == null) && (number == null)) {
                 return memberService.findAll();
             } else if ((type == null) || (number == null)) {
                 throw new BadRequestException("Requested value is invalid");
             } else {
-                return memberService.findSameGradeMember(type, number);
+                return memberService.findSameGradeMembers(type, number);
             }
         } else if ((type == null) && (number == null)) {
             return memberService.findMembersByName(name);

--- a/src/main/java/com/raisetech/membershipmanagement/controller/MemberController.java
+++ b/src/main/java/com/raisetech/membershipmanagement/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.raisetech.membershipmanagement.controller;
 
 import com.raisetech.membershipmanagement.entity.Member;
+import com.raisetech.membershipmanagement.exception.BadRequestException;
 import com.raisetech.membershipmanagement.service.MemberService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,25 +18,32 @@ public class MemberController {
         this.memberService = memberService;
     }
 
+    /* /members
+    クエリパラメータの入力がない場合は全件取得
+    type,numberどちらかの入力しかない場合BadRequestを返す処理
+    type,number両方入力がある場合は学年検索で該当する会員情報を取得
+    nameのみ入力がある場合は名前検索で該当する会員情報を取得
+    その他の場合はBadRequestを返す処理
+    */
     @GetMapping("/members")
-    public List<Member> getAllMembers() {
-        List<Member> allMembers = memberService.findAll();
-        return allMembers;
+    public List<Member> getMembers(@RequestParam String name, String type, Integer number) {
+        if (name == null) {
+            if ((type == null) && (number == null)) {
+                return memberService.findAll();
+            } else if ((type == null) || (number == null)) {
+                throw new BadRequestException("Requested value is invalid");
+            } else {
+                return memberService.findSameGradeMember(type, number);
+            }
+        } else if ((type == null) && (number == null)) {
+            return memberService.findMembersByName(name);
+        } else {
+            throw new BadRequestException("Requested value is invalid");
+        }
     }
 
     @GetMapping("/members/{id}")
     public Member getMember(@PathVariable("id") int id) {
         return memberService.findMember(id);
-    }
-
-    @GetMapping("/members/{type}/{number}")
-    public List<Member> getSameGradeMember(@PathVariable("type") String type, @PathVariable("number") int number) {
-        return memberService.findSameGradeMember(type, number);
-    }
-
-    @GetMapping("/ids")
-    public List<Integer> getIds(@RequestParam String name) {
-        List<Integer> ids = memberService.findId(name);
-        return ids;
     }
 }

--- a/src/main/java/com/raisetech/membershipmanagement/dao/MemberMapper.java
+++ b/src/main/java/com/raisetech/membershipmanagement/dao/MemberMapper.java
@@ -12,12 +12,12 @@ public interface MemberMapper {
     @Select("SELECT * FROM members")
     List<Member> findAll();
 
+    @Select("SELECT * FROM members WHERE school_name LIKE CONCAT('%',#{type},'%') AND grade=#{number}")
+    List<Member> findByGrade(String type, Integer number);
+
+    @Select("SELECT * FROM members WHERE name LIKE CONCAT('%',#{name},'%')")
+    List<Member> findByName(String name);
+
     @Select("SELECT * FROM members WHERE id = #{id}")
     Optional<Member> findById(int id);
-
-    @Select("SELECT * FROM members WHERE school_name LIKE CONCAT('%',#{type},'%') AND grade=#{number}")
-    List<Member> findByGrade(String type, int number);
-
-    @Select("SELECT id FROM members WHERE name LIKE CONCAT('%',#{name},'%')")
-    List<Integer> findByName(String name);
 }

--- a/src/main/java/com/raisetech/membershipmanagement/exception/BadRequestException.java
+++ b/src/main/java/com/raisetech/membershipmanagement/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.raisetech.membershipmanagement.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/raisetech/membershipmanagement/exception/MemberControllerExceptionHandler.java
+++ b/src/main/java/com/raisetech/membershipmanagement/exception/MemberControllerExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.raisetech.membershipmanagement.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@RestControllerAdvice
+public class MemberControllerExceptionHandler {
+    @ExceptionHandler(value = BadRequestException.class)
+    public ResponseEntity<Map<String, String>> handleBadRequestException(
+            BadRequestException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/raisetech/membershipmanagement/service/MemberService.java
+++ b/src/main/java/com/raisetech/membershipmanagement/service/MemberService.java
@@ -21,7 +21,7 @@ public class MemberService {
         return allMembers;
     }
 
-    public List<Member> findSameGradeMember(String type, Integer number) {
+    public List<Member> findSameGradeMembers(String type, Integer number) {
         List<Member> sameGradeMembers = this.memberMapper.findByGrade(type, number);
         return sameGradeMembers;
     }

--- a/src/main/java/com/raisetech/membershipmanagement/service/MemberService.java
+++ b/src/main/java/com/raisetech/membershipmanagement/service/MemberService.java
@@ -21,18 +21,19 @@ public class MemberService {
         return allMembers;
     }
 
+    public List<Member> findSameGradeMember(String type, Integer number) {
+        List<Member> sameGradeMembers = this.memberMapper.findByGrade(type, number);
+        return sameGradeMembers;
+    }
+
+    public List<Member> findMembersByName(String name) {
+        List<Member> members = this.memberMapper.findByName(name);
+        return members;
+    }
+
     public Member findMember(int id) {
         Optional<Member> member = this.memberMapper.findById(id);
         return member.orElseThrow(() -> new MemberNotFoundException("member not found"));
     }
 
-    public List<Member> findSameGradeMember(String type, int number) {
-        List<Member> sameGradeMembers = this.memberMapper.findByGrade(type, number);
-        return sameGradeMembers;
-    }
-
-    public List<Integer> findId(String name) {
-        List<Integer> ids = this.memberMapper.findByName(name);
-        return ids;
-    }
 }


### PR DESCRIPTION
# 概要
エンドポイントURL  ```/members``` で以下①～④の処理を実装したいと考えています。

①会員情報を全件取得
　クエリパラメーターなし

②名前検索で指定した会員情報を取得
　クエリパラメーター ```name``` を指定

③学年検索で指定した会員情報を取得
　クエリパラメーター ```type``` と ```number``` を指定

④下表でパターンA,B,Cのときは例外BadRequestExceptionを投げてステータスコード400を返す

クエリパラメーターの有無と処理 | ① | ②| A | B | ③ | C
-- | -- | -- | -- | -- | -- | --
name | × | 〇 | 〇 | 〇 | × | 〇
type | × | × | 〇 | × | 〇 | 〇
number | × | × | × | 〇 | 〇 | 〇
処理 | 全件取得 | 名前検索 | 400 | 400 | 学年検索 | 400

## 問題・疑問点
パターン②、A、B、Cの場合は想定したものが返ってくるのですが、①、③で400が返ってきます。
デバックで動きを追ってみようとコントローラーの条件分岐のところにブレークポイントを置いてみたのですが止まらずに400が返ってきました。
解決の糸口を教えていただきたいです。
どうぞよろしくお願いいたします

### 成功例
- パターン②
<img width="373" alt="image" src="https://github.com/yuik23/membershipmanagement/assets/121958929/bf6d3280-eac6-478e-9789-9a5ce667f719">

- パターンC
<img width="331" alt="image" src="https://github.com/yuik23/membershipmanagement/assets/121958929/3932b1a4-33a3-40a8-a8ea-7974b5f96b78">

### 失敗例
- パターン①
<img width="329" alt="image" src="https://github.com/yuik23/membershipmanagement/assets/121958929/43043a88-89dc-4541-b58c-3a9dc00a707a">

- パターン③
<img width="349" alt="image" src="https://github.com/yuik23/membershipmanagement/assets/121958929/73f8adc6-2c1b-441c-b50b-76253b5224f5">


